### PR TITLE
调用该库时可以不用unwrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+**/*.bak

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ license = "GPL-3.0"
 
 [dependencies]
 binder = { git = "https://github.com/shadow3aaa/binder_rs", package = "binder_ndk" }
-os_pipe = "1.2.0"
-thiserror = "1.0.61"
+os_pipe = "1.2.1"
+thiserror = "2.0.11"

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,5 +8,5 @@ pub enum DumpError {
     #[error("IO Error")]
     IO(#[from] io::Error),
     #[error("Dump error")]
-    DumpStatus(#[from] StatusCode)
+    DumpStatus(#[from] StatusCode),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,12 +25,12 @@ impl Dumpsys {
     ///
     /// Dumpsys::new("SurfaceFlinger");
     /// ```
-    pub fn new<S>(service_name: S) -> Option<Self>
+    pub fn new<S>(service_name: S) -> Self
     where
         S: AsRef<str>,
     {
-        let service = get_service(service_name.as_ref())?;
-        Some(Self { service })
+        let service = get_service(service_name.as_ref()).unwrap();
+        Self { service }
     }
 
     /// # Example


### PR DESCRIPTION
调用时可以这样: 
```rust
let output = Dumpsys::new("activity").dump(&["lru"]);
```
无需:
```rust
let output = Dumpsys::new("activity").unwrap().dump(&["lru"]);
```
主要是看着unwrap不爽
顺带更新依赖版本号