### PR TITLE
feat: use `rsbinder` to remove `libbinder_ndk` dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,20 @@
 [package]
 name = "dumpsys-rs"
-version = "0.1.1"
-edition = "2021"
-authors = ["shadow3"]
+version = "0.2.0"
+edition = "2024"
+authors = ["shadow3", "チセ <123655015+chise0713@users.noreply.github.com>"]
 readme = "README.md"
 repository = "https://github.com/shadow3aaa/dumpsys-rs"
 description = "`dumpsys-rs` is a Rust library for retrieving and dumping service information in an Android system. It provides a convenient way to fetch detailed status information from different system services, similar to the `dumpsys` command in the Android shell."
 license = "GPL-3.0"
 
+[[example]]
+name = "recents"
+
 [dependencies]
-binder = { git = "https://github.com/shadow3aaa/binder_rs", package = "binder_ndk" }
-os_pipe = "1.2.0"
-thiserror = "1.0.61"
+thiserror = "^1"
+twox-hash = { version = "^2", default-features = false, features = [
+    "std",
+    "xxhash3_64",
+] }
+rsbinder = { version = "^0.5", features = ["android_11_plus"] }

--- a/examples/recents.rs
+++ b/examples/recents.rs
@@ -1,0 +1,22 @@
+use std::collections::BTreeSet;
+
+use dumpsys_rs::Dumpsys;
+
+fn main() {
+    let mut dumpsys = Dumpsys::new().unwrap();
+    dumpsys.insert_service("activity").unwrap();
+    let dump = dumpsys.dump("activity", &["recents"]).unwrap();
+    let packages: BTreeSet<_> = dump
+        .split("Visible recent tasks")
+        .nth(1)
+        .map(|t| {
+            t.split("* RecentTaskInfo")
+                .skip(1)
+                .filter_map(|task| task.split("baseIntent=Intent").nth(1))
+                .filter_map(|s| s.split("cmp=").nth(1))
+                .filter_map(|s| s.split_once('/').map(|(pkg, _)| pkg.trim()))
+                .collect()
+        })
+        .unwrap_or_default();
+    println!("{:?}", packages);
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,17 @@
 use std::io;
 
-use binder::StatusCode;
-use thiserror::Error;
+use rsbinder::error::StatusCode;
 
-#[derive(Error, Debug)]
-pub enum DumpError {
-    #[error("IO Error")]
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
     IO(#[from] io::Error),
-    #[error("Dump error")]
-    DumpStatus(#[from] StatusCode)
+    #[error(transparent)]
+    DumpStatus(#[from] StatusCode),
+    #[error("invalid method call for current `Dumpsys` pipe-type")]
+    InvalidMethod,
+    #[error("service not exist")]
+    ServiceNotExist,
+    #[error("no such entry found in `Dumpsys`")]
+    NoEntryFound,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,90 @@
 pub mod error;
+mod task_thread;
 
-use std::{io::Read, os::fd::AsRawFd, sync::Arc, thread};
+use std::{
+    self,
+    collections::HashMap,
+    hash::BuildHasherDefault,
+    io::{self, PipeWriter, Read as _},
+    ops::Deref,
+    sync::{
+        Arc,
+        atomic::{AtomicI32, Ordering},
+    },
+};
 
-use binder::{binder_impl::IBinderInternal, get_service, SpIBinder, StatusCode};
+use rsbinder::{ProcessState, SIBinder, StatusCode, hub};
+use twox_hash::XxHash3_64;
 
-/// The main entry of this crate
-pub struct Dumpsys {
-    service: SpIBinder,
+use crate::{error::Error, task_thread::TaskThread};
+
+type Result<T, E = crate::error::Error> = core::result::Result<T, E>;
+
+/// One shot dumpsys
+///
+/// # Example
+///
+/// ```sh
+/// dumpsys SurfaceFlinger
+/// ```
+///
+/// is equal to
+///
+/// ```no_run
+/// # fn foo() -> Result<(), dumpsys_rs::error::Error> {
+/// dumpsys_rs::dump("SurfaceFlinger", &[])?;
+/// # Ok(())
+/// # }
+/// ```
+pub fn dump<S: AsRef<str>>(service_name: S, args: &[&str]) -> Result<String> {
+    _ = ProcessState::init_default();
+
+    let task_thread = TaskThread::spawn();
+
+    let service = hub::get_service(service_name.as_ref()).ok_or(Error::ServiceNotExist)?;
+
+    dump_inner(&task_thread, service, args)
 }
 
-impl Dumpsys {
+#[repr(transparent)]
+struct DumpArgs {
+    inner: Box<[String]>,
+}
+
+impl FromIterator<String> for DumpArgs {
+    fn from_iter<T: IntoIterator<Item = String>>(iter: T) -> Self {
+        let inner: Box<[String]> = iter.into_iter().collect();
+        Self { inner }
+    }
+}
+
+impl Deref for DumpArgs {
+    type Target = [String];
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+type StatusI32Slot = Arc<AtomicI32>;
+
+enum Task {
+    Dump(DumpArgs, PipeWriter, SIBinder, StatusI32Slot),
+    Shutdown,
+}
+
+/// Single retrieved existing services.
+///
+/// Like [`Dumpsys`], but use a task_thread exclusively.
+pub struct BoundDumpsys {
+    service: SIBinder,
+    task_thread: TaskThread,
+}
+
+impl BoundDumpsys {
     /// Retrieve an existing service and save it for dump, blocking for a few seconds if it doesn't yet exist.
     ///
-    /// For example
+    /// # Example
     ///
     /// ```sh
     /// dumpsys SurfaceFlinger
@@ -20,54 +92,116 @@ impl Dumpsys {
     ///
     /// is equal to
     ///
-    /// ```
-    /// use dumpsys_rs::Dumpsys;
+    /// ```no_run
+    /// use dumpsys_rs::BoundDumpsys;
     ///
-    /// Dumpsys::new("SurfaceFlinger");
-    /// ```
-    pub fn new<S>(service_name: S) -> Option<Self>
-    where
-        S: AsRef<str>,
-    {
-        let service = get_service(service_name.as_ref())?;
-        Some(Self { service })
-    }
-
-    /// # Example
-    ///
-    /// ```
-    /// use dumpsys_rs::Dumpsys;
-    ///
-    /// # fn foo() -> Option<()> {
-    /// let result = Dumpsys::new("SurfaceFlinger")?
-    ///     .dump(&["--latency"])
-    ///     .unwrap();
-    /// println!("{result}");
-    /// # Some(())
+    /// # fn foo() -> Result<(), dumpsys_rs::error::Error> {
+    /// let mut dumpsys = BoundDumpsys::new("SurfaceFlinger")?;
+    /// let result = dumpsys
+    ///     .dump(&[])?;
+    /// # Ok(())
     /// # }
     /// ```
-    pub fn dump(&self, args: &[&str]) -> Result<String, error::DumpError> {
-        let mut buf = String::new();
+    pub fn new<S: AsRef<str>>(service_name: S) -> Result<Self> {
+        _ = ProcessState::init_default();
 
-        {
-            let (mut read, write) = os_pipe::pipe()?;
-            let handle = thread::spawn(magic(self.service.clone(), write, args));
-            let _ = read.read_to_string(&mut buf);
-            handle.join().unwrap()?;
-        }
+        Ok(Self {
+            service: hub::get_service(service_name.as_ref()).ok_or(Error::ServiceNotExist)?,
+            task_thread: TaskThread::spawn(),
+        })
+    }
 
-        Ok(buf)
+    pub fn dump(&self, args: &[&str]) -> Result<String> {
+        dump_inner(&self.task_thread, self.service.clone(), args)
     }
 }
 
-fn magic(
-    mut service: SpIBinder,
-    write: impl AsRawFd + Send + 'static,
-    args: &[&str],
-) -> impl FnOnce() -> Result<(), StatusCode> + Send + 'static {
-    let args: Box<[Arc<str>]> = args.into_iter().map(|s| Arc::from(*s)).collect();
-    move || {
-        let args: Box<[&str]> = args.iter().map(|s| s.as_ref()).collect();
-        service.dump(&write, &args)
+type XxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<XxHash3_64>>;
+
+/// Retrieved existing services.
+///
+/// Drop [`Dumpsys`] will exit the background pipeing thread
+pub struct Dumpsys {
+    map: XxHashMap<Box<str>, SIBinder>,
+    task_thread: TaskThread,
+}
+
+impl Dumpsys {
+    pub fn new() -> Result<Self> {
+        _ = ProcessState::init_default();
+
+        Ok(Self {
+            map: XxHashMap::default(),
+            task_thread: TaskThread::spawn(),
+        })
     }
+
+    /// Retrieve an existing service and save it for dump, blocking for a few seconds if it doesn't yet exist.
+    ///
+    /// # Example
+    ///
+    /// ```sh
+    /// dumpsys SurfaceFlinger
+    /// ```
+    ///
+    /// is equal to
+    ///
+    /// ```no_run
+    /// use dumpsys_rs::Dumpsys;
+    ///
+    /// # fn foo() -> Result<(), dumpsys_rs::error::Error> {
+    /// let mut dumpsys = Dumpsys::new()?;
+    /// dumpsys.insert_service("SurfaceFlinger")?;
+    /// let result = dumpsys
+    ///     .dump("SurfaceFlinger", &[])?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn insert_service<S: AsRef<str>>(&mut self, service_name: S) -> Result<bool> {
+        let service_name = service_name.as_ref();
+
+        let service = hub::get_service(service_name).ok_or(Error::ServiceNotExist)?;
+
+        Ok(self.map.insert(Box::from(service_name), service).is_some())
+    }
+
+    /// Removes the selected service from the inner [`HashMap`].
+    pub fn remove_service<S: AsRef<str>>(&mut self, service_name: S) -> Result<SIBinder> {
+        let service_name = service_name.as_ref();
+
+        self.map.remove(service_name).ok_or(Error::NoEntryFound)
+    }
+
+    pub fn dump<S: AsRef<str>>(&mut self, service_name: S, args: &[&str]) -> Result<String> {
+        let service_name = service_name.as_ref();
+
+        let service = self.map.get(service_name).ok_or(Error::NoEntryFound)?;
+
+        dump_inner(&self.task_thread, service.clone(), args)
+    }
+}
+
+fn dump_inner(task_thread: &TaskThread, service: SIBinder, args: &[&str]) -> Result<String> {
+    let (mut reader, writer) = io::pipe()?;
+
+    let status_i32 = Arc::new(AtomicI32::new(i32::from(StatusCode::Ok)));
+
+    task_thread
+        .send(Task::Dump(
+            DumpArgs::from_iter(args.iter().copied().map(String::from)),
+            writer,
+            service,
+            status_i32.clone(),
+        ))
+        .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "task_thread dropped receiver"))?;
+
+    let mut buf = String::new();
+    reader.read_to_string(&mut buf)?;
+
+    let status_code = StatusCode::from(status_i32.load(Ordering::Relaxed));
+    if !matches!(status_code, StatusCode::Ok) {
+        Err(status_code)?;
+    }
+
+    Ok(buf)
 }

--- a/src/task_thread.rs
+++ b/src/task_thread.rs
@@ -1,0 +1,51 @@
+use std::{
+    sync::{
+        atomic::Ordering,
+        mpsc::{self, SendError, Sender},
+    },
+    thread,
+};
+
+use crate::Task;
+
+pub struct TaskThread {
+    tx: Sender<Task>,
+}
+
+impl TaskThread {
+    pub fn spawn() -> Self {
+        let (tx, rx) = mpsc::channel();
+
+        thread::spawn(move || {
+            while let Ok(task) = rx.recv() {
+                let (args, writer, service, status) = match task {
+                    Task::Dump(a, w, s, e) => (a, w, s, e),
+                    Task::Shutdown => break,
+                };
+
+                // continue drops writer, reader will get an EOF
+                let Some(proxy) = service.as_proxy() else {
+                    continue;
+                };
+
+                // if failed then return the StatusCode back to calling thread
+                let _ = proxy
+                    .dump(writer, &args)
+                    .inspect_err(|e| status.store(i32::from(*e), Ordering::Relaxed));
+            }
+        });
+
+        Self { tx }
+    }
+
+    #[inline(always)]
+    pub fn send(&self, t: Task) -> Result<(), SendError<Task>> {
+        self.tx.send(t)
+    }
+}
+
+impl Drop for TaskThread {
+    fn drop(&mut self) {
+        let _ = self.tx.send(Task::Shutdown);
+    }
+}


### PR DESCRIPTION
- depending on `libbinder_ndk` often leads to linking issues, so this pr refactors the repo to use Rust native `rsbinder`

- also it might have some performance gain? because it uses the background thread, instead of spawn a new one in every `dump` call, reduces context switch (might

also adds myself to the authors, dk whether this is acceptable (if not feel free to just remove it), and an [example](https://github.com/shadow3aaa/dumpsys-rs/pull/3/changes#diff-c0379f318bdf46be269c50137b1866c2d967b7c0f753eb6b01f0321b5ef4dfa7) for testing

this `rsbinder` might be too bloaty..? didn't check that, if not appropriate then feel free to just close the pr

thanks!